### PR TITLE
feat: Display GitHub on the top and bottom of the repository page

### DIFF
--- a/src/components/externalLink/index.jsx
+++ b/src/components/externalLink/index.jsx
@@ -2,31 +2,35 @@ import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 
-import { ExternalLink as ExternalLinkLinkIcon } from "../icons";
+import { ExternalLink as ExternalLinkIcon } from "../icons";
 
 import "./index.scss";
 
-const ExternalLink = ({ to, className, children, noIcon, ...args }) => (
-  <a
-    href={to}
-    className={classnames(
-      "external-link",
-      { "external-link--inline": noIcon },
-      className,
-    )}
-    target="_blank"
-    rel="noopener noreferrer"
-    {...args}
-  >
-    {children}
-    {!noIcon && <ExternalLinkLinkIcon className="external-link__icon" />}
-  </a>
-);
+const ExternalLink = ({ to, className, children, noIcon, icon, ...args }) => {
+  const Icon = icon || ExternalLinkIcon;
+  return (
+    <a
+      href={to}
+      className={classnames(
+        "external-link",
+        { "external-link--inline": noIcon },
+        className,
+      )}
+      target="_blank"
+      rel="noopener noreferrer"
+      {...args}
+    >
+      {children}
+      {!noIcon && <Icon className="external-link__icon" />}
+    </a>
+  );
+};
 
 ExternalLink.propTypes = {
   to: PropTypes.string.isRequired,
   className: PropTypes.string,
   noIcon: PropTypes.bool,
+  icon: PropTypes.object,
   args: PropTypes.object,
 };
 

--- a/src/components/footer/index.jsx
+++ b/src/components/footer/index.jsx
@@ -3,6 +3,8 @@ import { Link } from "gatsby";
 
 import { SECTIONS, LAYOUTS } from "../../constants";
 
+import { GitHub } from "../icons";
+
 import ExternalLink from "../externalLink";
 import SiteTitle from "../siteTitle";
 
@@ -25,6 +27,7 @@ const Footer = () => (
         data-section={SECTIONS.FOOTER_NAV}
         data-layout={LAYOUTS.LIST}
         className="accent"
+        icon={GitHub}
       >
         Follow on GitHub
       </ExternalLink>

--- a/src/components/icons/index.jsx
+++ b/src/components/icons/index.jsx
@@ -58,3 +58,20 @@ export const Arrow = ({ className, left }) => (
     <polyline points="12 5 19 12 12 19"></polyline>
   </svg>
 );
+
+export const GitHub = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={classnames("feather feather-github", className)}
+  >
+    <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+  </svg>
+);

--- a/src/templates/repository/index.jsx
+++ b/src/templates/repository/index.jsx
@@ -11,7 +11,7 @@ import { useNavigation } from "../../hooks/useNavigation";
 
 import { getRepositoryInfos } from "../../utils/repository";
 
-import { Arrow } from "../../components/icons";
+import { Arrow, GitHub } from "../../components/icons";
 
 import ExternalLink from "../../components/externalLink";
 import Layout from "../../components/layout";
@@ -57,6 +57,17 @@ const RepositoryPage = ({ data, location }) => {
         <Arrow left className="repository__nav-link-icon" />
         back
       </Link>
+      <ExternalLink
+        to={githubUrl}
+        data-section={
+          bottom ? SECTIONS.REPOSITORY_BOTTOM_NAV : SECTIONS.REPOSITORY_NAV
+        }
+        data-layout={LAYOUTS.LIST}
+        className="repository__nav-link"
+        icon={GitHub}
+      >
+        GitHub
+      </ExternalLink>
     </nav>
   );
 
@@ -71,29 +82,21 @@ const RepositoryPage = ({ data, location }) => {
       <article className="repository">
         <header className="repository__hero">
           <Nav />
-          <div className="repository__header">
-            <RepositoryTitle ownerName={ownerName} name={name} tag="h1" />
-            <ExternalLink
-              to={githubUrl}
-              data-section={SECTIONS.REPOSITORY_HEADER}
-              data-layout={LAYOUTS.LIST}
-              className="repository__nav-link"
-            >
-              GitHub
-            </ExternalLink>
-          </div>
+          <RepositoryTitle ownerName={ownerName} name={name} tag="h1" />
           <p>{description}</p>
         </header>
-        {!!featuredImage && (
-          <ZoomableImage
-            image={featuredImage}
-            alt="featured"
-            className="repository__image"
-            data-section={SECTIONS.REPOSITORY_MAIN_IMAGE}
-            data-layout={LAYOUTS.BLOCK}
-          />
-        )}
-        {!!images && images.length > 0 && <Mosaic images={images} />}
+        <section>
+          {!!featuredImage && (
+            <ZoomableImage
+              image={featuredImage}
+              alt="featured"
+              className="repository__image"
+              data-section={SECTIONS.REPOSITORY_MAIN_IMAGE}
+              data-layout={LAYOUTS.BLOCK}
+            />
+          )}
+          {!!images && images.length > 0 && <Mosaic images={images} />}
+        </section>
       </article>
       <Nav bottom />
     </Layout>

--- a/src/templates/repository/index.scss
+++ b/src/templates/repository/index.scss
@@ -4,12 +4,6 @@
   margin-bottom: 2rem;
 }
 
-.repository__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
 .repository__image {
   padding: 1rem;
   margin: -1rem -1rem 2rem -1rem;
@@ -20,6 +14,9 @@
 }
 
 .repository__nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 2rem;
   &--bottom {
     margin-bottom: 0;
@@ -33,6 +30,7 @@
   display: flex;
   align-items: center;
   width: min-content;
+  font-weight: bold;
 }
 
 .repository__nav-link-icon {

--- a/src/templates/repository/index.scss
+++ b/src/templates/repository/index.scss
@@ -30,7 +30,6 @@
   display: flex;
   align-items: center;
   width: min-content;
-  font-weight: bold;
 }
 
 .repository__nav-link-icon {


### PR DESCRIPTION
Closes #72 

The top link was easily skippable. Adding it to the bottom too (like the back button) makes it easier to be seen.

Also add a GitHub icon to use on the GitHub links