### PR TITLE
fix: Center card position on focus

### DIFF
--- a/src/components/actions/index.jsx
+++ b/src/components/actions/index.jsx
@@ -19,6 +19,7 @@ const Actions = ({ actions, activeAction }) => (
           data-section={SECTIONS.ACTIONS}
           data-layout={LAYOUTS.LIST}
           to={action.route}
+          aria-label={`${action.label} vim color schemes`}
         >
           {action.label}
         </Link>

--- a/src/components/card/index.jsx
+++ b/src/components/card/index.jsx
@@ -27,40 +27,41 @@ const Card = ({ repository, linkId, linkTabIndex, linkState, className }) => {
 
   return (
     <li className={classnames("card", className)}>
-      <div className="card__image">
-        {!!featuredImage && (
-          <Img
-            fluid={featuredImage.childImageSharp.fluid}
-            alt={`${ownerName} ${name}`}
-            imgStyle={{ objectFit: "contain" }}
-          />
-        )}
-      </div>
-      <div className="card__header">
-        <h3 className="card__title">
-          <Link
-            to={`/${URLify(`${ownerName}/${name}`)}`}
-            state={linkState}
-            id={linkId}
-            tabIndex={linkTabIndex}
-            data-section={SECTIONS.REPOSITORIES}
-            data-layout={LAYOUTS.GRID}
-          >
-            <RepositoryTitle ownerName={ownerName} name={name} />
-          </Link>
-        </h3>
-        <div className="card__stargazers">
-          <Star className="card__stargazers-icon" />
-          <span className="card__stargazers-count">{stargazersCount}</span>
+      <Link
+        to={`/${URLify(`${ownerName}/${name}`)}`}
+        state={linkState}
+        id={linkId}
+        tabIndex={linkTabIndex}
+        data-section={SECTIONS.REPOSITORIES}
+        data-layout={LAYOUTS.GRID}
+        aria-label={`${name}, by ${ownerName}`}
+      >
+        <div className="card__image">
+          {!!featuredImage && (
+            <Img
+              fluid={featuredImage.childImageSharp.fluid}
+              alt={`${ownerName} ${name}`}
+              imgStyle={{ objectFit: "contain" }}
+            />
+          )}
         </div>
-      </div>
-      <p className="card__infos">{description}</p>
-      <p className="card__infos">
-        Created <strong>{createdAt}</strong>
-      </p>
-      <p className="card__infos">
-        Last commit <strong>{lastCommitAt}</strong>
-      </p>
+        <div className="card__header">
+          <h3 className="card__title">
+            <RepositoryTitle ownerName={ownerName} name={name} />
+          </h3>
+          <div className="card__stargazers">
+            <Star className="card__stargazers-icon" />
+            <span className="card__stargazers-count">{stargazersCount}</span>
+          </div>
+        </div>
+        <p className="card__infos">{description}</p>
+        <p className="card__infos">
+          Created <strong>{createdAt}</strong>
+        </p>
+        <p className="card__infos">
+          Last commit <strong>{lastCommitAt}</strong>
+        </p>
+      </Link>
     </li>
   );
 };

--- a/src/components/card/index.scss
+++ b/src/components/card/index.scss
@@ -9,26 +9,6 @@
   padding: 1rem;
 }
 
-.card__title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.card__title > a::after {
-  content: " ";
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-
-.card__title > a:focus {
-  text-decoration: underline;
-  outline: none;
-  box-shadow: none;
-}
-
 .card:hover {
   @include hover-border;
 }
@@ -37,15 +17,26 @@
   @include focus-border;
 }
 
-.card:focus-within a {
+.card > a {
+  display: flex;
+  flex-direction: column;
+  box-shadow: none;
+}
+
+.card > a:focus {
+  text-decoration: underline;
+  outline: none;
+}
+
+.card:focus-within > a {
   text-decoration: none;
   outline: none;
   box-shadow: none;
 }
 
-.card__title > a {
-  display: flex;
-  flex-direction: column;
+.card__title {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .card__header {

--- a/src/components/externalLink/index.jsx
+++ b/src/components/externalLink/index.jsx
@@ -30,7 +30,7 @@ ExternalLink.propTypes = {
   to: PropTypes.string.isRequired,
   className: PropTypes.string,
   noIcon: PropTypes.bool,
-  icon: PropTypes.object,
+  icon: PropTypes.func,
   args: PropTypes.object,
 };
 

--- a/src/components/siteTitle/index.jsx
+++ b/src/components/siteTitle/index.jsx
@@ -41,7 +41,7 @@ const SiteTitle = ({
       data-section={section}
       data-layout={layout}
     >
-      <img src={logo} alt="colorschemes logo" className="site-title__logo" />
+      <img src={logo} alt="" className="site-title__logo" />
       <Heading className="site-title__name">
         <span className="site-title__name-part">{platform}</span>
         <span className="site-title__name-part">{title}</span>

--- a/src/components/zoomableImage/index.jsx
+++ b/src/components/zoomableImage/index.jsx
@@ -21,6 +21,25 @@ const ZoomableImage = ({ image, className, ...inputArgs }) => {
     />
   );
 
+  const onKeyDown = event => {
+    const { key, target } = event;
+
+    // pressed key is not handled by app.
+    // Keeps doing what it was about to do.
+    if (!Object.values(KEYS).includes(key)) return;
+
+    // checkbox toggle keys
+    if ([KEYS.SPACE, KEYS.ENTER].includes(event.key)) {
+      event.preventDefault();
+      target.checked = !target.checked;
+      return;
+    }
+
+    // Anything else keeps doing what it was about to do,
+    // but also unchecks the checkbox
+    target.checked = false;
+  };
+
   return (
     <label className="zoomable">
       <input
@@ -28,24 +47,8 @@ const ZoomableImage = ({ image, className, ...inputArgs }) => {
         type="checkbox"
         className="zoomable__toggle"
         name="image-toggle"
-        onKeyDown={event => {
-          const { key, target } = event;
-
-          // pressed key is not handled by app.
-          // Keeps doing what it was about to do.
-          if (!Object.values(KEYS).includes(key)) return;
-
-          // checkbox toggle keys
-          if ([KEYS.SPACE, KEYS.ENTER].includes(event.key)) {
-            event.preventDefault();
-            target.checked = !target.checked;
-            return;
-          }
-
-          // Anything else keeps doing what it was about to do,
-          // but also unchecks the checkbox
-          target.checked = false;
-        }}
+        onKeyDown={onKeyDown}
+        aria-label="Zoom on focused image"
         {...inputArgs}
       />
       <div className={classnames("zoomable__container", className)}>

--- a/src/components/zoomableImage/index.scss
+++ b/src/components/zoomableImage/index.scss
@@ -2,6 +2,9 @@
 
 .zoomable {
   position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .zoomable__container {
@@ -23,30 +26,33 @@
   position: absolute;
   top: 0;
   left: 0;
+  width: 100%;
+  height: 100%;
   opacity: 0;
-  &:focus + .zoomable__container {
-    @include focus-border;
-  }
-  &:hover + .zoomable__container {
-    @include hover-border;
-  }
-  &:checked ~ .zoomable__modal {
-    display: block;
-    transition: none;
-    transform: scale(1);
-    position: fixed;
-    background-color: rgba(#242424, 0.95);
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    z-index: 10;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    & > .zoomable__image {
-      max-width: 90%;
-      max-height: 90%;
-    }
+}
+
+.zoomable__toggle:focus + .zoomable__container {
+  @include focus-border;
+}
+.zoomable__toggle:hover + .zoomable__container {
+  @include hover-border;
+}
+.zoomable__toggle:checked ~ .zoomable__modal {
+  display: block;
+  transition: none;
+  transform: scale(1);
+  position: fixed;
+  background-color: rgba(#242424, 0.95);
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 10;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  & > .zoomable__image {
+    max-width: 90%;
+    max-height: 90%;
   }
 }

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -237,6 +237,7 @@ const getNextTabIndexOfPreviousSection = (
 };
 
 // return true if the given element is visible in the viewport
+// source: https://gomakethings.com/how-to-test-if-an-element-is-in-the-viewport-with-vanilla-javascript/
 const isInViewport = element => {
   const bounding = element.getBoundingClientRect();
   const clientHeight =

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -236,11 +236,29 @@ const getNextTabIndexOfPreviousSection = (
   return null;
 };
 
+// return true if the given element is visible in the viewport
+const isInViewport = element => {
+  const bounding = element.getBoundingClientRect();
+  const clientHeight =
+    window?.innerHeight || document?.documentElement.clientHeight;
+  const clientWidth =
+    window?.innerWidth || document?.documentElement.clientWidth;
+  return (
+    bounding.top >= 0 &&
+    bounding.left >= 0 &&
+    bounding.bottom <= clientHeight &&
+    bounding.right <= clientWidth
+  );
+};
+
 // focus on a tab index if the element exists
 const focus = (focusables, index) => {
   const nextElement = focusables[index];
   if (nextElement) {
-    nextElement.scrollIntoView({ block: "center" });
+    if (!isInViewport(nextElement)) {
+      console.log("scroll");
+      nextElement.scrollIntoView({ block: "center" });
+    }
     nextElement.focus({ preventScroll: true });
   }
 };

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -239,7 +239,10 @@ const getNextTabIndexOfPreviousSection = (
 // focus on a tab index if the element exists
 const focus = (focusables, index) => {
   const nextElement = focusables[index];
-  nextElement && nextElement.focus();
+  if (nextElement) {
+    nextElement.scrollIntoView({ block: "center" });
+    nextElement.focus({ preventScroll: true });
+  }
 };
 
 // get all focusable elements of the current tab index's section


### PR DESCRIPTION
Closes #79 

**What was done:**

Even though it is not as accessible as before, using the `a` tag as the card wrapper fixes its position when focused. The other option was to use javascript to guess the scroll value, and scroll back to that value.

To counter the loss of accessibility, an aria-label was added to the card link.

**Also in this PR (a bunch of accessibility stuff):**

* Aria labels on actions
* Aria labels on the zoomable image input
* Scroll to focused element **only** if it is not in viewport
* Remove alt tag on the main logo to improve the experience with a screen reader
* Fix prop types on the external link component
* Make zoomable image input full size (to improve position on focus)