### PR TITLE
Fix cmd + up/down arrows navigation on mac

### DIFF
--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -20,7 +20,7 @@ export const useNavigation = defaultSection => {
 const handleKeyPress = (event, focusables, defaultSection) => {
   const { key } = event;
 
-  if (NON_NAVIGATION_KEYS.includes(key)) return;
+  if (NON_NAVIGATION_KEYS.includes(key) || event.metaKey) return;
 
   if (
     [

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -18,9 +18,9 @@ export const useNavigation = defaultSection => {
 };
 
 const handleKeyPress = (event, focusables, defaultSection) => {
-  const { key } = event;
+  const { key, metaKey } = event;
 
-  if (NON_NAVIGATION_KEYS.includes(key) || event.metaKey) return;
+  if (NON_NAVIGATION_KEYS.includes(key)) return;
 
   if (
     [
@@ -28,7 +28,8 @@ const handleKeyPress = (event, focusables, defaultSection) => {
       KEYS.ARROW_RIGHT,
       KEYS.ARROW_DOWN,
       KEYS.ARROW_LEFT,
-    ].includes(key)
+    ].includes(key) &&
+    !metaKey
   ) {
     event.preventDefault();
   }
@@ -43,7 +44,13 @@ const handleKeyPress = (event, focusables, defaultSection) => {
   const { section, layout } = activeElement.dataset;
 
   let nextTabIndex;
-  if (key === KEYS.TOP) {
+  if (metaKey) {
+    if ([KEYS.UP, KEYS.ARROW_UP].includes(key)) {
+      nextTabIndex = 0;
+    } else if ([KEYS.DOWN, KEYS.ARROW_DOWN].includes(key)) {
+      nextTabIndex = focusables.length - 1;
+    }
+  } else if (key === KEYS.TOP) {
     nextTabIndex = getFirstTabIndexOfSection(focusables, SECTIONS.REPOSITORIES);
   } else if (key === KEYS.BOTTOM) {
     nextTabIndex = getLastTabIndexOfSection(focusables, SECTIONS.REPOSITORIES);


### PR DESCRIPTION
I couldn't test locally (I don't have docker/mongodb/etc installed) so I just modified the script on the live website and it seems to work fine. (Using chrome's **local overrides** feature, I just started using it it's pretty nice 👀)

Closes #148 