### PR TITLE
 tried to resolve -> bug: Unresponsive theme switch in production

### DIFF
--- a/src/components/themeSwitch/index.jsx
+++ b/src/components/themeSwitch/index.jsx
@@ -17,7 +17,7 @@ const ThemeSwitch = inputArgs => {
   }, [isBrowser]);
 
   return (
-    <label className="theme-switch">
+    <label className="theme-switch" tabIndex="0" role="switch" aria-checked={theme === THEMES.DARK} >
       <input
         type="checkbox"
         className="theme-switch__input"


### PR DESCRIPTION
@reobin 
usage of label as clickable is incorrect according to the semantics of HTML.
[https://www.456bereastreet.com/archive/201302/making_elements_keyboard_focusable_and_clickable/](https://www.456bereastreet.com/archive/201302/making_elements_keyboard_focusable_and_clickable/
)I tried to give the fix.
`    <label className="theme-switch" tabIndex="0" role="switch" aria-checked={theme === THEMES.DARK} >
`
please see if it solves the problem.