### PR TITLE
centered pagination on mobile

### DIFF
--- a/src/components/pagination/index.scss
+++ b/src/components/pagination/index.scss
@@ -10,7 +10,12 @@
 }
 
 .pagination__page-status {
-  margin: 0 3rem;
+  display: flex;
+  justify-content: center;
+  position: absolute;
+  width: 100%;
+  z-index: -1;
+  margin: 0;
 }
 
 .pagination__link-block {
@@ -44,5 +49,11 @@
   }
   .pagination__link--limit {
     display: block;
+  }
+
+  .pagination__page-status {
+    margin: 0 3rem;
+    position: relative;
+    width: auto;
   }
 }


### PR DESCRIPTION
This PR fixes alignment for the pagination component on a mobile.

The final look, displayed on the screenshot:

![image](https://user-images.githubusercontent.com/3904240/94799920-2b5eec00-03e4-11eb-84b8-b9bbdf4646b6.png)




Fixes: #38 