### PR TITLE
feat(header): revamp header on mobile

### DIFF
--- a/src/components/actions/index.jsx
+++ b/src/components/actions/index.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { Link } from "gatsby";
 
@@ -6,27 +6,36 @@ import { LAYOUTS, SECTIONS } from "src/constants";
 
 import "./index.scss";
 
-const Actions = ({ actions, activeAction }) => (
-  <ul className="actions">
-    {actions.map((action, index) => (
-      <li
-        key={`${action.route}-${index}`}
-        className={`actions__item ${
-          activeAction === action ? "actions__item--active" : ""
-        }`}
-      >
-        <Link
-          data-section={SECTIONS.ACTIONS}
-          data-layout={LAYOUTS.LIST}
-          to={action.route}
-          aria-label={`${action.label} vim color schemes`}
+const Actions = ({ actions, activeAction }) => {
+
+  useEffect(() => {
+    document.querySelector('.actions__item--active')
+      .scrollIntoView(false);
+  }, []);
+
+  return (
+    <ul className="actions">
+      {actions.map((action, index) => (
+        <li
+          key={`${action.route}-${index}`}
+          className={`actions__item ${
+            activeAction === action ? "actions__item--active" : ""
+          }`}
         >
-          {action.label}
-        </Link>
-      </li>
-    ))}
-  </ul>
-);
+          <Link
+            data-section={SECTIONS.ACTIONS}
+            data-layout={LAYOUTS.LIST}
+            to={action.route}
+            aria-label={`${action.label} vim color schemes`}
+          >
+            {action.label}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 
 const actionType = PropTypes.shape({
   label: PropTypes.string.isRequired,

--- a/src/components/actions/index.scss
+++ b/src/components/actions/index.scss
@@ -3,9 +3,11 @@
 .actions {
   width: 100%;
   display: flex;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-  margin: 1rem -1rem;
+  align-items: center;
+  margin: 0 0 1rem;
+  padding: 0.5rem 0;
+  overflow-x: auto;
+  box-shadow: 5px 0 5px -5px rgba(51, 51, 51, 0.23);
 }
 
 .actions__item {
@@ -57,4 +59,16 @@
   border: none;
   box-shadow: none;
   text-decoration: none;
+}
+
+@include md {
+  .actions {
+    align-items: unset;
+    justify-content: flex-end;
+    margin: 1rem -1rem;
+    padding: 0;
+    flex-wrap: wrap; 
+    overflow-x: hidden;
+    box-shadow: none;
+  }
 }

--- a/src/components/actions/index.scss
+++ b/src/components/actions/index.scss
@@ -15,6 +15,7 @@
   padding: 1rem;
   position: relative;
   margin-left: 1rem;
+  white-space: nowrap;
   &:first-of-type {
     margin-left: 0;
   }

--- a/src/components/header/index.scss
+++ b/src/components/header/index.scss
@@ -2,7 +2,7 @@
 
 .header {
   min-height: 5rem;
-  padding: 2rem 0 0;
+  padding: 0 0.5rem;
   display: flex;
   align-items: center;
   position: relative;
@@ -11,13 +11,11 @@
 .header__content {
   @include container-layout;
   display: flex;
-  flex-direction: column-reverse;
   justify-content: space-between;
   align-items: center;
 }
 
 .header__sub-content {
-  margin-bottom: 2rem;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -51,7 +49,6 @@
     flex-direction: row;
   }
   .header__sub-content {
-    margin-bottom: 0;
     flex-direction: row;
     align-items: center;
     & > * {

--- a/src/components/intro/index.scss
+++ b/src/components/intro/index.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  max-width: 90%;
+  max-width: 70%;
   margin: 1rem auto;
   & > * {
     text-align: center;
@@ -14,7 +14,7 @@
   }
 
   .subtitle {
-    font-size: 1rem;
+    font-size: 1.25rem;
   }
 }
 

--- a/src/components/intro/index.scss
+++ b/src/components/intro/index.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  max-width: 60%;
+  max-width: 90%;
   margin: 1rem auto;
   & > * {
     text-align: center;

--- a/src/components/intro/index.scss
+++ b/src/components/intro/index.scss
@@ -12,6 +12,10 @@
   & * + * {
     margin-top: 1rem;
   }
+
+  .subtitle {
+    font-size: 1rem;
+  }
 }
 
 .intro__highlight {
@@ -26,6 +30,10 @@
   .intro {
     margin: 3rem 0;
     max-width: unset;
+
+    .subtitle {
+      font-size: 1.5rem;
+    }
   }
   .intro__instruction {
     display: block;

--- a/src/components/layout/index.scss
+++ b/src/components/layout/index.scss
@@ -21,6 +21,10 @@ body,
   flex-direction: column;
   @include container-layout;
   flex: 1;
-  padding-top: 1rem;
+  padding-top: 0.5rem;
   padding-bottom: 1rem;
+}
+
+@include md {
+  padding-top: 1rem;
 }

--- a/src/components/layout/index.scss
+++ b/src/components/layout/index.scss
@@ -26,5 +26,7 @@ body,
 }
 
 @include md {
-  padding-top: 1rem;
+  .main {
+    padding-top: 1rem;
+  }
 }

--- a/src/components/siteTitle/index.scss
+++ b/src/components/siteTitle/index.scss
@@ -7,10 +7,11 @@
   padding: 0.5rem;
   margin: -1rem;
   width: min-content;
+  font-size: 1rem;
 }
 
 .site-title__logo {
-  height: 2rem;
+  height: 2.5em;
 }
 
 .site-title:not(.site-title--vertical) {
@@ -21,7 +22,7 @@
 
 .site-title__name-part {
   color: var(--text-pale);
-  font-size: 1rem;
+  font-size: 1em;
   text-decoration: none;
   margin: 0;
   &:first-of-type {
@@ -36,11 +37,7 @@
 }
 
 @include lg {
-  .site-title__name-part {
-    font-size: 2rem;
-  }
-
-  .site-title__logo {
-    height: 5rem;
+  .site-title {
+    font-size: 2em;
   }
 }

--- a/src/components/siteTitle/index.scss
+++ b/src/components/siteTitle/index.scss
@@ -2,20 +2,26 @@
 
 .site-title {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  padding: 1rem;
+  padding: 0.5rem;
   margin: -1rem;
   width: min-content;
 }
 
 .site-title__logo {
-  height: 5rem;
+  height: 2rem;
+}
+
+.site-title:not(.site-title--vertical) {
+  & .site-title__name {
+    margin-left: 0.5rem;
+  }
 }
 
 .site-title__name-part {
   color: var(--text-pale);
-  font-size: 2rem;
+  font-size: 1rem;
   text-decoration: none;
   margin: 0;
   &:first-of-type {
@@ -23,11 +29,18 @@
   }
 }
 
+@include md {
+  .site-title {
+    padding: 1rem;
+  }
+}
+
 @include lg {
-  .site-title:not(.site-title--vertical) {
-    flex-direction: row;
-    & .site-title__name {
-      margin-left: 0.5rem;
-    }
+  .site-title__name-part {
+    font-size: 2rem;
+  }
+
+  .site-title__logo {
+    height: 5rem;
   }
 }

--- a/src/components/themeSwitch/index.scss
+++ b/src/components/themeSwitch/index.scss
@@ -1,7 +1,7 @@
 @import "src/style/mixins/index";
 
 .theme-switch {
-  padding: 1rem;
+  padding: 0.5rem;
   margin: -1rem;
   cursor: pointer;
 }
@@ -18,4 +18,10 @@
   margin: 0;
   width: 0;
   opacity: 0;
+}
+
+@include md {
+  .theme-switch {
+    padding: 1rem;
+  }
 }


### PR DESCRIPTION
Resolve #134 

### Checklist
- Aligned the logo and theme switch in a row on mobile
- Decreased the size of some spacings on mobile
- Updated the filters to be a horizontal list with scroll on mobile, and added a small right box-shadow to be an indicator.
- Added an useEffect on the actions component, just to force a scroll when the page loads (for example if someone access directly the /oldest route/filter)

Proof:

<img width="378" alt="Screen Shot 2020-10-01 at 11 34 36" src="https://user-images.githubusercontent.com/8248179/94823328-1e3cff80-03da-11eb-8650-af44639cadfc.png">

Let me know if I miss something :)

