### PR TITLE
inverted robots.txt env variable

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -28,9 +28,9 @@ module.exports = {
           },
           production: {
             policy: [
-              process.env.GATSBY_DISABLE_ROBOTS
-                ? { userAgent: "*", disallow: ["/"] }
-                : { userAgent: "*", allow: ["/"] },
+              process.env.GATSBY_ENABLE_ROBOTS
+                ? { userAgent: "*", allow: ["/"] }
+                : { userAgent: "*", disallow: ["/"] },
             ],
           },
         },


### PR DESCRIPTION
Hi @reobin 

I've inverted the robots.txt env variable. A new one is GATSBY_ENABLE_ROBOTS. 

By default robots disallowed. I didn't find vercel CI config in the repo, could you please set in PROD build GATSBY_ENABLE_ROBOTS=true, to enable robots.txt for production.

Thanks