### PR TITLE
fix: disable hover styles on touch devices

### DIFF
--- a/src/style/mixins/index.scss
+++ b/src/style/mixins/index.scss
@@ -12,7 +12,9 @@
 }
 
 @mixin hover-border {
-  box-shadow: 0px 4px 0px -2px var(--focus-border);
-  outline: none;
-  cursor: pointer;
+  @media (hover: hover) and (pointer: fine) {
+    box-shadow: 0px 4px 0px -2px var(--focus-border);
+    outline: none;
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update

## Description

Disables hover styles on touch devices.

## Related issue

Closes #204 

## Added unit tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no
