### PR TITLE
fix: Fix unresponsive dark theme switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,17 +43,17 @@
   ],
   "license": "GNU General Public License v3.0",
   "scripts": {
-    "build": "gatsby build",
-    "develop": "gatsby develop",
-    "serve": "gatsby serve",
     "start": "npm run develop",
     "start::local": "npm run develop -- -H 0.0.0.0",
+    "develop": "gatsby develop",
+    "build": "gatsby build",
+    "build::preview": "npm run clean && npm run build",
+    "serve": "gatsby serve",
     "clean": "gatsby clean",
     "seed": "sh db/seed.sh",
-    "preview::build": "npm run clean && npm run build",
     "format": "prettier --write \"**/*.{js,jsx,json,md,css,scss}\"",
     "test": "jest --silent",
-    "test::vocal": "jest"
+    "test::verbose": "jest"
   },
   "repository": {
     "type": "git",

--- a/src/components/siteTitle/index.jsx
+++ b/src/components/siteTitle/index.jsx
@@ -1,7 +1,7 @@
 import React from "react";
+import { Link } from "gatsby";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { Link, useStaticQuery, graphql } from "gatsby";
 
 import { SECTIONS, LAYOUTS } from "src/constants";
 

--- a/src/components/themeSwitch/index.jsx
+++ b/src/components/themeSwitch/index.jsx
@@ -7,7 +7,7 @@ import "./index.scss";
 const ThemeSwitch = inputArgs => {
   const isBrowser = typeof window !== "undefined";
 
-  const [theme, setTheme] = useState(isBrowser ? window.__theme : undefined);
+  const [theme, setTheme] = useState();
 
   useEffect(() => {
     if (isBrowser) {
@@ -41,9 +41,11 @@ const ThemeSwitch = inputArgs => {
         }}
         {...inputArgs}
       />
-      <span>
-        dark theme: <strong>{theme === THEMES.DARK ? "on" : "off"}</strong>
-      </span>
+      {!!theme && (
+        <span>
+          dark theme: <strong>{theme === THEMES.DARK ? "on" : "off"}</strong>
+        </span>
+      )}
     </label>
   );
 };

--- a/src/html.jsx
+++ b/src/html.jsx
@@ -27,31 +27,31 @@ const HTML = props => (
       <script
         dangerouslySetInnerHTML={{
           __html: `
-              (function() {
-                window.__onThemeChange = function() {};
-                function setTheme(theme) {
-                  window.__theme = theme;
-                  preferredTheme = theme;
-                  document.body.className = theme;
-                  window.__onThemeChange(theme);
-                }
-                var preferredTheme;
+            (function() {
+              window.__onThemeChange = function() {};
+              function setTheme(newTheme) {
+                window.__theme = newTheme;
+                preferredTheme = newTheme;
+                document.body.className = newTheme;
+                window.__onThemeChange(newTheme);
+              }
+              var preferredTheme;
+              try {
+                preferredTheme = localStorage.getItem("${THEME_KEY}");
+              } catch (err) { }
+              window.__setPreferredTheme = function(newTheme) {
+                setTheme(newTheme);
                 try {
-                  preferredTheme = localStorage.getItem("${THEME_KEY}");
-                } catch {}
-                window.__setPreferredTheme = function(theme) {
-                  setTheme(theme);
-                  try {
-                    localStorage.setItem("${THEME_KEY}", theme);
-                  } catch {}
-                }
-                var mql = window.matchMedia("(prefers-color-scheme: dark)");
-                mql.addListener(function(e) {
-                  window.__setPreferredTheme(e.matches ? "${THEMES.DARK}" : "${THEMES.LIGHT}");
-                });
-                setTheme(preferredTheme || (mql.matches ? "${THEMES.DARK}" : "${THEMES.LIGHT}"));
-              })();
-            `,
+                  localStorage.setItem("${THEME_KEY}", newTheme);
+                } catch (err) {}
+              }
+              var darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
+              darkQuery.addListener(function(event) {
+                window.__setPreferredTheme(e.matches ? "${THEMES.DARK}" : "${THEMES.LIGHT}")
+              });
+              setTheme(preferredTheme || (darkQuery.matches ? "${THEMES.DARK}" : "${THEMES.LIGHT}"));
+            })();
+          `,
         }}
       />
       {props.preBodyComponents}


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update

## Description

Fixed the theme switch on the initial load when the theme is dark.

## Related issue

Closes #99 

<!-- Replace this line with "Closes #<issue number>" if it's the case -->

## QA Instructions

1. Set theme to dark
2. Reload page
3. Notice it no longer takes 3 clicks to change theme

## Added unit tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no
