### PR TITLE
test: Add E2E tests for theme switch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,3 +34,4 @@ jobs:
         env:
           GATSBY_DATABASE_CONNECTION_STRING: ${{ secrets.GATSBY_DATABASE_CONNECTION_STRING }}
           GATSBY_SITE_URL: https://localhost:9000
+          CYPRESS_RECORD_KEY: ${{ CYPRESS_RECORD_KEY }}

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:8000"
+  "baseUrl": "http://localhost:8000",
+  "projectId": "qogexn"
 }

--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -1,5 +1,5 @@
-describe("The Home Page", () => {
-  it('successfully loads the app & checks for "vim" header content', () => {
+describe("Home page", () => {
+  it("should load the app & checks for the site title", () => {
     cy.visit("/");
     cy.contains("vimcolorschemes");
   });

--- a/cypress/integration/theme_switch_spec.js
+++ b/cypress/integration/theme_switch_spec.js
@@ -1,0 +1,80 @@
+const LIGHT_THEME_LABEL = "dark theme: off";
+const DARK_THEME_LABEL = "dark theme: on";
+const LIGHT_THEME_BODY_CLASS = "light";
+const DARK_THEME_BODY_CLASS = "dark";
+
+describe("Theme switch", () => {
+  it("should default to light", () => {
+    cy.visit("/");
+
+    cy.contains(LIGHT_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", LIGHT_THEME_BODY_CLASS);
+  });
+
+  it("should switch to dark on click", () => {
+    cy.visit("/");
+
+    cy.get(".theme-switch").click();
+
+    cy.contains(DARK_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", DARK_THEME_BODY_CLASS);
+  });
+
+  it("should load dark after change and refresh", () => {
+    cy.visit("/");
+
+    cy.contains(LIGHT_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", LIGHT_THEME_BODY_CLASS);
+
+    cy.get(".theme-switch").click();
+
+    cy.contains(DARK_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", DARK_THEME_BODY_CLASS);
+
+    cy.reload();
+
+    cy.contains(DARK_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", DARK_THEME_BODY_CLASS);
+  });
+
+  it("should switch to light after loading dark after reload", () => {
+    cy.visit("/");
+
+    cy.contains(LIGHT_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", LIGHT_THEME_BODY_CLASS);
+
+    cy.get(".theme-switch").click();
+
+    cy.contains(DARK_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", DARK_THEME_BODY_CLASS);
+
+    cy.reload();
+
+    cy.contains(DARK_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", DARK_THEME_BODY_CLASS);
+
+    cy.reload();
+
+    cy.get(".theme-switch").click();
+
+    cy.contains(LIGHT_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", LIGHT_THEME_BODY_CLASS);
+  });
+
+  it("should toggle on shortcut press", () => {
+    cy.visit("/");
+
+    cy.contains(LIGHT_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", LIGHT_THEME_BODY_CLASS);
+
+    cy.document().trigger("keydown", { key: "b" });
+
+    cy.contains(DARK_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", DARK_THEME_BODY_CLASS);
+
+    cy.document().trigger("keydown", { key: "b" });
+
+    cy.contains(LIGHT_THEME_LABEL).should("be.visible");
+    cy.get("body").should("have.class", LIGHT_THEME_BODY_CLASS);
+  });
+});


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Optimization
- [ ] Documentation update

## Description

Add E2E for theme switch.

Tests:
- initial load
- after refresh
- switch click
- shortcut press

## Related issue

N/A
<!-- Replace this line with "Closes #<issue number>" if it's the case -->

## QA Instructions

`npm run test::e2e`

## Added unit tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no
